### PR TITLE
Reset server attempt count after each commit checkout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -187,6 +187,7 @@ class GitLapse {
         });
 
         // Wait for the web server to come online within specified timeout
+        this.serverAttempts = 0;
         this.pollServer((err) => {
           if (err) throw new Error(err);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,7 @@ class GitLapse {
       if (err) throw new Error(err);
 
       logger.timer('slideshow', true);
-      console.log(`All done! Screenshots are in ${path.resolve(this.config.output)}`, 'bgGreen');
+      console.log(`\n\nAll done! Output is in ${path.resolve(this.config.output)}`);
       return;
     });
 


### PR DESCRIPTION
This is the number of times we have tried to connect to the server
after checking out the next commit and the setup script has been
run. It should therefore be a 'per commit' count, rather than
a global count for the whole process.

The main reason behind this is that sometimes a server can take
a while to render the first page. For example Rails can take a few
seconds to precompile all the assets when the source code changes.